### PR TITLE
Add workaround for Quartus limitation

### DIFF
--- a/rggen_axi4lite_if.sv
+++ b/rggen_axi4lite_if.sv
@@ -1,11 +1,9 @@
-interface rggen_axi4lite_if
-  import  rggen_rtl_pkg::*;
-#(
+interface rggen_axi4lite_if #(
   parameter int ID_WIDTH      = 0,
   parameter int ADDRESS_WIDTH = 16,
   parameter int BUS_WIDTH     = 32
 );
-  localparam  int ACTUAL_ID_WIDTH = rggen_clip_width(ID_WIDTH);
+  localparam  int ACTUAL_ID_WIDTH = rggen_rtl_pkg::rggen_clip_width(ID_WIDTH);
 
   logic                       awvalid;
   logic                       awready;

--- a/rggen_wishbone_if.sv
+++ b/rggen_wishbone_if.sv
@@ -1,6 +1,4 @@
-interface rggen_wishbone_if
-  import  rggen_rtl_pkg::*;
-#(
+interface rggen_wishbone_if #(
   parameter int ADDRESS_WIDTH = 16,
   parameter int DATA_WIDTH    = 32
 );


### PR DESCRIPTION
fix rggen/rggen-sv-rtl#18

It seems that Quartus does not support `import` declaration in interface header.
This PR adds workaround for this limitation.